### PR TITLE
Add support for embedded debug type

### DIFF
--- a/src/ResourceEmbedder.Core/DebugSymbolHelper.cs
+++ b/src/ResourceEmbedder.Core/DebugSymbolHelper.cs
@@ -14,18 +14,11 @@ namespace ResourceEmbedder.Core
         /// <returns></returns>
         public static DebugSymbolType FromString(string input)
         {
-            if (string.IsNullOrEmpty(input) ||
-                "none".Equals(input, StringComparison.OrdinalIgnoreCase))
-                return DebugSymbolType.None;
-            if ("portable".Equals(input, StringComparison.OrdinalIgnoreCase))
-                return DebugSymbolType.Portable;
-            if ("full".Equals(input, StringComparison.OrdinalIgnoreCase))
-                return DebugSymbolType.Full;
-            if ("pdb-only".Equals(input, StringComparison.OrdinalIgnoreCase) ||
-                "pdbonly".Equals(input, StringComparison.OrdinalIgnoreCase))
-                return DebugSymbolType.PdbOnly;
-
-            throw new NotSupportedException("Unsupported " + input);
+            if (Enum.TryParse(input, ignoreCase: true, out DebugSymbolType debugType))
+            {
+                return debugType;
+            }
+            throw new NotSupportedException($"DebugType '{input}' is not supported.");
         }
     }
 }

--- a/src/ResourceEmbedder.MsBuild/SatelliteAssemblyEmbedderTask.cs
+++ b/src/ResourceEmbedder.MsBuild/SatelliteAssemblyEmbedderTask.cs
@@ -83,7 +83,7 @@ namespace ResourceEmbedder.MsBuild
             var rp = CecilBasedAssemblyModifier.GetReaderParameters(inputAssembly, searchDirs, symbolReader);
             if (!SignAssembly)
             {
-                if (DebugSymbols && !File.Exists(Path.ChangeExtension(inputAssembly, ".pdb")))
+                if (DebugSymbols && debugSymbolType != DebugSymbolType.Embedded && !File.Exists(Path.ChangeExtension(inputAssembly, ".pdb")))
                 {
                     // can't call ReadModule with DebugSymbols=true when .pdb is missing; since we most likely won't end up producing working output anyway
                     // just ignore the sign assembly check


### PR DESCRIPTION
Using Enum.TryParse since "pdb-only" is not a supported value anyway. This is the error we get if we try to use <DebugType>pdb-only</DebugType>
> Error CS1902 : Invalid option 'pdb-only' for /debug; must be 'portable', 'embedded', 'full' or 'pdbonly'