### PR TITLE
Full support for embedded symbols rewriting

### DIFF
--- a/src/ResourceEmbedder.MsBuild.Tests/ResourceEmbedder.MsBuild.Tests.csproj
+++ b/src/ResourceEmbedder.MsBuild.Tests/ResourceEmbedder.MsBuild.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/testmodules/Symbols/FullFramework/Embedded/Embedded.csproj
+++ b/src/testmodules/Symbols/FullFramework/Embedded/Embedded.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <!--
+        .NET Framework 4.7.2 is required for proper support of portable/embedded symbols.
+        See https://github.com/microsoft/dotnet/blob/37165eac02f7fdbbc04efffdd32c378ca70c00fa/releases/net471/KnownIssues/517815-BCL%20Stack%20traces%20are%20missing%20source%20information%20for%20frames%20with%20debug%20information%20in%20the%20Portable%20PDB%20format.md
+    -->
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/testmodules/Symbols/FullFramework/Embedded/Program.cs
+++ b/src/testmodules/Symbols/FullFramework/Embedded/Program.cs
@@ -24,6 +24,17 @@ namespace Embedded
             {
                 Environment.Exit(-3);
             }
+            try
+            {
+                throw new Exception("Ensuring that debug symbols are embedded.");
+            }
+            catch (Exception exception)
+            {
+                if (!exception.StackTrace.Contains("Program.cs"))
+                {
+                    Environment.Exit(-4);
+                }
+            }
             Environment.Exit(0);
         }
 


### PR DESCRIPTION
Commit ab29ec7d7c4eccc62f45444d09228d85c566cb16 did not actually add full support for embedded debug symbols.

Also improve embedded symbols test to ensure that symbols are embedded by testing that we have the source file in the stack trace. This only works on .NET Framework 4.7.2 and later.