### PR TITLE
Fix EmbedderTarget order

### DIFF
--- a/src/ResourceEmbedder.MsBuild/build/Resource.Embedder.props
+++ b/src/ResourceEmbedder.MsBuild/build/Resource.Embedder.props
@@ -12,9 +12,29 @@
   <!--
   We want to run as soon as the satellite assemblies are generated
 
-  Two AfterTargets because Core* is for .Net Core only and the other one for Full framework only.. luckily MSBuild seems to OR the condition automatically
+  We are using two targets (EmbedderTarget + CoreEmbedderTarget) with idential tasks to handle both
+  `MSBuild` (GenerateSatelliteAssemblies) and `dotnet build` (CoreGenerateSatelliteAssemblies).
+
+  Unfortunately, we can not define the `AfterTargets` attribute value in a property group because the
+  $(GenerateSatelliteAssembliesForCore) property is defined too late in the build process, i.e. this does *not* work:
+
+  <EmbedderTargetAfter Condition=" '$(EmbedderTargetAfter)' == '' and '$(GenerateSatelliteAssembliesForCore)' != 'true' ">GenerateSatelliteAssemblies</EmbedderTargetAfter>
+  <EmbedderTargetAfter Condition=" '$(EmbedderTargetAfter)' == '' and '$(GenerateSatelliteAssembliesForCore)' == 'true' ">CoreGenerateSatelliteAssemblies</EmbedderTargetAfter>
   -->
-  <Target AfterTargets="GenerateSatelliteAssemblies;CoreGenerateSatelliteAssemblies" Name="EmbedderTarget">
+  <Target AfterTargets="GenerateSatelliteAssemblies" Name="EmbedderTarget" Condition=" '$(GenerateSatelliteAssembliesForCore)' != 'true' ">
+    <ResourceEmbedder.MsBuild.SatelliteAssemblyEmbedderTask AssemblyPath="@(IntermediateAssembly)"
+                                                            IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"
+                                                            KeyFilePath="$(AssemblyOriginatorKeyFile)"
+                                                            ProjectDirectory="$(ProjectDir)"
+                                                            TargetPath="$(TargetPath)"
+                                                            SignAssembly="$(EmbedderSignAssembly)"
+                                                            References="@(ReferencePath)"
+                                                            DebugSymbols="$(DebugSymbols)"
+                                                            DebugType="$(DebugType)">
+      <Output TaskParameter="EmbeddedCultures" PropertyName="EmbeddedCultures" />
+    </ResourceEmbedder.MsBuild.SatelliteAssemblyEmbedderTask>
+  </Target>
+  <Target AfterTargets="CoreGenerateSatelliteAssemblies" Name="CoreEmbedderTarget" Condition=" '$(GenerateSatelliteAssembliesForCore)' == 'true' ">
     <ResourceEmbedder.MsBuild.SatelliteAssemblyEmbedderTask AssemblyPath="@(IntermediateAssembly)"
                                                             IntermediateDirectory="$(ProjectDir)$(IntermediateOutputPath)"
                                                             KeyFilePath="$(AssemblyOriginatorKeyFile)"


### PR DESCRIPTION
The comment was saying "luckily MSBuild seems to OR the condition automatically" but unfortunately this is not true.

When running `MSBuild`, the order of the targets is correct:  
✅ GenerateSatelliteAssemblies → EmbedderTarget

When running `dotnet build`, the order of the targets is wrong:  
❌ EmbedderTarget → CoreGenerateSatelliteAssemblies

In order to make sure the EmbedderTarget runs after the satellite assemblies are generated, we use a condition on the `GenerateSatelliteAssembliesForCore` property (which is used to conditionally run both [GenerateSatelliteAssemblies][1] and [CoreGenerateSatelliteAssemblies][2] targets).

[1]: https://github.com/dotnet/msbuild/blob/v16.9.0/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3714
[2]: https://github.com/dotnet/sdk/blob/v5.0.202/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L883