### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/DotNetCore.Tests/DotNetCore.Tests.csproj
+++ b/src/DotNetCore.Tests/DotNetCore.Tests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.17" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.17" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@MarcStan, I found an issue in the DotNetCore.Tests.csproj:

Packages Microsoft.AspNetCore.Mvc.Testing v3.1.14, Microsoft.AspNetCore.TestHost v3.1.14, Microsoft.NET.Test.Sdk v16.9.4, NUnit v3.13.1 and NUnit3TestAdapter v3.17.0 transitively introduce 95 dependencies into resource-embedder’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/resource-embedder.html)), while Microsoft.AspNetCore.Mvc.Testing v3.1.17, Microsoft.AspNetCore.TestHost v3.1.17, Microsoft.NET.Test.Sdk v16.10.0, NUnit v3.13.2 and NUnit3TestAdapter v4.0.0 can only introduce 61 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/resource-embedder_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose